### PR TITLE
Include changes from Jordan LeDoux

### DIFF
--- a/implement_future_rules_for_granting_voting_karma.md
+++ b/implement_future_rules_for_granting_voting_karma.md
@@ -23,10 +23,13 @@ Voting karma should in future be granted on request if
 The requester should search a proponent of their case that then proposes the request for voting karma to the 
 dedicated discussion medium for such requests. The proposal should include the reasons why the proponent thinks 
 the requester fullfills the above stated requirements. After this request there will be a two week period in which 
-objections and approvals will be brought in. When there are more approvals than objections the voting karma will
-be granted.
+objections and approvals will be brought in. Once this period is over, if there are more approvals than objections 
+the voting karma will be granted.
 
 Currently the dedicated discussion medium is the internals mailinglist at internals@php.net
+
+A list of people that are willing to act as proponents and/or mentors would be a gread addition but is not
+part of this RFC
 
 ## Backward Incompatible Changes
 There will be no backwards incompatible changes. Currently granted karma is not subject to discussion. 
@@ -75,6 +78,8 @@ thing the discussion around how voting karma is granted and why some people have
 not waste resources and also people that *want* karma can now follow a clear path and guidance. This will also 
 improve the overall interaction with the PHP core contributors - whether that touches src, docs, bugs or 
 infrastructure.
+
+Creating a list of people volunteering to act as proponents and/or mentors
 
 ## Proposed Voting Choices
 


### PR DESCRIPTION
These were changes that Jordan LeDoux submitted via Email (jordan.ledoux@gmail.com) to internals@

> Another aspect that I thought about after reading your draft was a way to
structurally avoid concerns about stacking. I don't believe that there
would necessarily be overt efforts to grant karma to individuals to push
certain concerns to the side, however it might be worth considering if the
process could promote a variety of opinions and backgrounds. Even if such a
situation were considered unlikely, it could be worth writing such a
process with that in mind if the process involves a sponsor.
>
> As I said earlier, it makes sense for many reasons to require a sponsor to
get voting karma, however this may unnecessarily make the applicant
associated with their sponsor or their sponsor's history and contributions
(which could be a positive or negative to one person or the other). It also
makes it less likely that a perspective which is totally unrepresented gets
sponsored. This could also be a positive thing, as not all perspectives are
truly relevant or constructive to all the processes. But it might be worth
considering these impacts explicitly.
> 
> It's also worth considering if people believe that this is a process that
will be iterated on or if there is a desire to get it right the first time
and stick with it. Perhaps if the intent is to iterate, or at least
explicitly revisit the criteria, the RFC could include an expiration at
which time a vote to either keep or change the process could be held, which
gives everyone clarity and certainty about the structure over a given
period.
> 
> Those are my immediate thoughts on your rough draft.
